### PR TITLE
add test for MicroTimer

### DIFF
--- a/api-chrono-test/src/MicroTimerTest.cpp
+++ b/api-chrono-test/src/MicroTimerTest.cpp
@@ -1,18 +1,252 @@
 #include "MicroTimerTest.hpp"
-
-MicroTimerTest::MicroTimerTest() : Test("chrono::MiroTimer")
+#include "sapi/chrono.hpp"
+MicroTimerTest::MicroTimerTest() : Test("chrono::MicroTimer")
 {
 
 }
 
 bool MicroTimerTest::execute_class_api_case(){
     bool result = true;
+    const u32 delay_time_usec = 100;
+    const u32 delay_time_msec = 10;
+    const u32 delay_time_sec = 1;
+    MicroTimer timer_count;
+    MicroTime time_test;
+    u32 time_usec,time_msec,time_sec;
+    timer_count.start();
+    timer_count.wait_usec(delay_time_usec);
+    //for incredible add resume
+    timer_count.resume();
+    if (timer_count.calc_usec() < delay_time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if (timer_count.calc_usec() > 2*delay_time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+
+    timer_count.stop();
+    time_usec = timer_count.calc_usec();
+    time_test = timer_count.calc_value();
+    if(time_test.microseconds() != time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if (time_usec < delay_time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if (time_usec > 2*delay_time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+
+    timer_count.stop();
+    if(time_usec != timer_count.calc_usec()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_usec()!=timer_count.usec()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.reset();
+    if(timer_count.calc_usec()!=0){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.wait_usec(delay_time_usec);
+    if(timer_count.calc_usec()!=0){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.restart();
+    timer_count.wait_usec(delay_time_usec);
+    timer_count.stop();
+    time_usec = timer_count.calc_usec();
+    if (time_usec < delay_time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.stop();
+    if(time_usec != timer_count.calc_usec()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.resume();
+    timer_count.wait_usec(delay_time_usec);
+    time_usec = timer_count.calc_usec();
+    if (time_usec < 2*delay_time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.restart();
+    if(timer_count.calc_usec() > delay_time_usec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.is_stopped()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(!timer_count.is_started()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(!timer_count.is_running()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.is_reset()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    //after stop
+    timer_count.stop();
+    if(!timer_count.is_stopped()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    //has been started
+    if(!timer_count.is_started()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.is_running()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.is_reset()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    //after reset
+    timer_count.reset();
+    if(timer_count.calc_usec()!=0){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_msec()!=0){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_sec()!=0){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(!timer_count.is_stopped()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    //has been started
+    if(timer_count.is_started()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.is_running()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(!timer_count.is_reset()){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    //msec
+    timer_count.restart();
+    timer_count.wait_msec(delay_time_msec);
+    timer_count.stop();
+    time_msec = timer_count.calc_msec();
+    time_test = timer_count.calc_value();
+    if(time_test.milliseconds() != time_msec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+
+    if(timer_count.calc_msec()<delay_time_msec||
+       timer_count.calc_msec()>(delay_time_msec*2)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_msec()!=(timer_count.calc_usec()/1000)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.resume();
+    timer_count.wait_msec(delay_time_msec);
+    if(timer_count.calc_msec()<(2*delay_time_msec)){
+        print_case_message("micro calc_masec %lu ",timer_count.calc_msec());
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_msec()!=(timer_count.calc_usec()/1000)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    //sec
+    timer_count.restart();
+    timer_count.wait_sec(delay_time_sec);
+    timer_count.stop();
+    time_sec = timer_count.calc_sec();
+    time_test = timer_count.calc_value();
+    if(time_test.seconds() != time_sec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_sec() != delay_time_sec){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_sec()!=(timer_count.calc_msec()/1000)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_msec()!=(timer_count.calc_usec()/1000)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    timer_count.resume();
+    timer_count.wait_sec(delay_time_sec);
+    if(timer_count.calc_sec()<(2*delay_time_sec)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_sec()!=(timer_count.calc_msec()/1000)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
+    if(timer_count.calc_msec()!=(timer_count.calc_usec()/1000)){
+        print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+        result = false;
+    }
 
     return result;
 }
 
 bool MicroTimerTest::execute_class_stress_case(){
     bool result = true;
+    const u32 delay_time_usec = 100;
+    MicroTimer timer_count;
+    u32 time_usec,temp_usec;
+    time_usec = 0;
+    for (u16 i = 1;i<10000;i++){
+        timer_count.start();
+        timer_count.wait_usec(delay_time_usec);
+        temp_usec = timer_count.calc_usec();
+        //timer_count.resume();
+        if(temp_usec < i*delay_time_usec){
+            print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+            result = false;
+            break;
+        }
 
+        if(temp_usec > (time_usec + (i+1)*delay_time_usec)){
+            print_case_message("Failed %s:%d", __PRETTY_FUNCTION__, __LINE__);
+            print_case_message("Failed %lu:%lu:%lu", timer_count.calc_usec(), (time_usec + (i+1)*delay_time_usec),i);
+            result = false;
+            break;
+        }
+        time_usec = timer_count.calc_usec();
+    }
     return result;
 }

--- a/api-chrono-test/src/TimeTest.cpp
+++ b/api-chrono-test/src/TimeTest.cpp
@@ -1,13 +1,23 @@
 #include "TimeTest.hpp"
-
+#include "sapi/chrono.hpp"
+#include "ctime"
 TimeTest::TimeTest() : Test("chrono::Time"){
 
 }
 
-
+/*! \details test "api" a chrono::Time
+ *  constructors,
+ * @return false if some test failed
+ */
 bool TimeTest::execute_class_api_case(){
     bool result = true;
-
+    MicroTimer timer_sh;
+    Time now(0,18,18);
+    time_t time_of_day;
+    timer_sh.start();
+    time_of_day = now.get_time_of_day();
+    timer_sh.wait_sec(1);
+    time_of_day = now.get_time_of_day();
     return result;
 }
 

--- a/api-chrono-test/src/main.cpp
+++ b/api-chrono-test/src/main.cpp
@@ -69,7 +69,7 @@ u32 decode_cli(const Cli & cli, u32 & execute_flags){
     //update switches
     if(cli.is_option("-test_all") ){ o_flags = 0xffffffff; }
     if(cli.is_option("-micro_time") ){ o_flags |= MICRO_TIME_TEST_FLAG; }
-    if(cli.is_option("-micro_timer") ){ o_flags |= MICRO_TIMER_TEST_FLAG; }
+    if(cli.is_option("-microtimer") ){ o_flags |= MICRO_TIMER_TEST_FLAG; }
     if(cli.is_option("-time") ){ o_flags |= TIME_TEST_FLAG; }
 
     return o_flags;


### PR DESCRIPTION
Running with arguments for the MicroTimer test, for example
      api-chrono-test -execute_all -micro_timer
      procces does not start with debugging information
      12001819062: 29.2: 804A1D0 - CRITICAL - Heap error
temporarily make -microtimer